### PR TITLE
Fix #314 security taglib, Maven and integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,12 @@ cache:
   - $HOME/.m2
 addons:
   firefox: latest
+  chrome: stable
 
 before_script:
   - echo "Extracting firefox and setting PATH variable..."
   - tar -xjf /tmp/firefox-*.tar.bz2 --directory /tmp
   - export PATH="/tmp/firefox:$PATH"
-  - echo "Downloading chrome..."
-  - wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-  - sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-  - sudo apt-get update
-  - sudo apt-get install google-chrome-stable
 
 install: ./mvnw -B clean validate
 

--- a/README.md
+++ b/README.md
@@ -33,10 +33,12 @@ mvn clean install
 
 3- Run
 ```Shell
-java -jar target/joinfaces-example-4.0.1-SNAPSHOT.jar
+java -jar target/joinfaces-example-4.1.1.jar
 ```
 
 4- Access starter page at **http://localhost:8080/**
+
+Optional: If your IDE is showing build errors install [Lombok](https://projectlombok.org/setup/overview)
 
 ## Key Files
 
@@ -46,7 +48,7 @@ Includes joinfaces starter dependency. All other jsf dependencies are included t
 
 ```xml
 <properties>
-   <joinfaces.version>4.0.1</joinfaces.version>
+   <joinfaces.version>4.1.1</joinfaces.version>
 </properties>
 
 <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -25,10 +25,10 @@
         <maven-model.version>3.6.0</maven-model.version>
 
         <!-- test library versions -->
-        <selenium.version>3.141.5</selenium.version>
-        <htmlunit-driver.version>2.33.2</htmlunit-driver.version>
-        <htmlunit.version>2.33</htmlunit.version>
-        <webdrivermanager.version>3.0.0</webdrivermanager.version>
+        <selenium.version>3.141.59</selenium.version>
+        <htmlunit-driver.version>2.37.0</htmlunit-driver.version>
+        <htmlunit.version>2.37.0</htmlunit.version>
+        <webdrivermanager.version>3.8.1</webdrivermanager.version>
         <jarchivelib.version>1.0.0</jarchivelib.version>
 
         <jacoco-maven-plugin.version>0.8.2</jacoco-maven-plugin.version>        
@@ -185,6 +185,12 @@
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-io</groupId>
+                    <artifactId>commons-io</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/src/main/java/org/joinfaces/example/view/JoinFacesStarterService.java
+++ b/src/main/java/org/joinfaces/example/view/JoinFacesStarterService.java
@@ -176,7 +176,7 @@ public class JoinFacesStarterService {
 
 	private Model createModel() throws MalformedURLException, IOException, XmlPullParserException {
 		MavenXpp3Reader mavenXpp3Reader = new MavenXpp3Reader();
-		return mavenXpp3Reader.read(new URL("http://repo1.maven.org/maven2/org/joinfaces/joinfaces-dependencies/"
+		return mavenXpp3Reader.read(new URL("https://repo1.maven.org/maven2/org/joinfaces/joinfaces-dependencies/"
 				+ joinfacesVersion + "/joinfaces-dependencies-" + joinfacesVersion + ".pom").openStream());
 	}
 

--- a/src/main/resources/META-INF/resources/starter.xhtml
+++ b/src/main/resources/META-INF/resources/starter.xhtml
@@ -7,7 +7,7 @@
                 xmlns:p="http://primefaces.org/ui"
                 xmlns:pe="http://primefaces.org/ui/extensions"
                 xmlns:o="http://omnifaces.org/ui"
-                xmlns:sec="http://www.springframework.org/security/tags"
+                xmlns:sec="https://joinfaces.org/security"
                 template="/template.xhtml">
     <ui:define name="content" >
         <p:panelGrid columns="2" layout="grid">

--- a/src/test/java/org/joinfaces/example/view/AbstractPageIT.java
+++ b/src/test/java/org/joinfaces/example/view/AbstractPageIT.java
@@ -21,6 +21,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.FirefoxProfile;
@@ -66,7 +67,10 @@ public class AbstractPageIT {
 
 	private static WebDriver getChromeDriver() {
 		WebDriverManager.getInstance(ChromeDriver.class).setup();
-		return new ChromeDriver();
+		ChromeOptions options = new ChromeOptions();
+		options.addArguments("--headless");
+		options.addArguments("--disable-gpu");
+		return new ChromeDriver(options);
 	}
 
 	private static WebDriver getFirefoxDriver() {


### PR DESCRIPTION
Fix #314

The namespace on the [homepage](http://joinfaces.org/#spring-security-jsf-facelet-tag-support) also needs to be updated under heading "Spring Security JSF Facelet Tag support" to match the [reference guide](https://docs.joinfaces.org/current/reference/#_spring_security_jsf_facelet_tag_support)