### PR TITLE
Replaced deprecated WebSecurityConfigurerAdapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ This SAP (Single Page Application) illustrates JSF usage inside JAR packaged Spr
 
 ## See Example Application in the cloud
 
-1- Access starter.jsf page at **https://joinfaces-example.herokuapp.com/**. This page can help you to choose the JoinFaces Starter that fits your needs. You may login with credentials
+1- Access starter.jsf page at **https://joinfaces-example.herokuapp.com/**. This page can help you to choose the JoinFaces Starter that fits your needs. You may log in with credentials
 
-User | Password | Roles
------| -------- | -----
-persapiens | 123 | ROLE_ADMIN
-nyilmaz | qwe | ROLE_USER
+| User       | Password | Roles      |
+|------------|----------|------------|
+| persapiens | 123      | ROLE_ADMIN |
+| nyilmaz    | qwe      | ROLE_USER  |
 
 ## Run Example Application locally
 

--- a/src/checkconfig/pmd/pmd-ruleset.xml
+++ b/src/checkconfig/pmd/pmd-ruleset.xml
@@ -63,13 +63,10 @@ under the License.
     <rule ref="category/java/errorprone.xml/UnnecessaryConversionTemporary" />
     <rule ref="category/java/errorprone.xml/UnusedNullCheckInEquals" />
     <rule ref="category/java/errorprone.xml/UselessOperationOnImmutable" />
-    <rule ref="category/java/errorprone.xml/ImportFromSamePackage" />
     <rule ref="category/java/errorprone.xml/CloneMethodMustBePublic" />
     <rule ref="category/java/errorprone.xml/CloneMethodMustImplementCloneable" />
     <rule ref="category/java/errorprone.xml/CloneMethodReturnTypeMustMatchClassName" />
-    <rule ref="category/java/errorprone.xml/CloneThrowsCloneNotSupportedException" />
-    <rule ref="category/java/errorprone.xml/ProperCloneImplementation" />    
-    <rule ref="category/java/errorprone.xml/CloneMethodMustImplementCloneable" />
+    <rule ref="category/java/errorprone.xml/ProperCloneImplementation" />
     <rule ref="category/java/errorprone.xml/AvoidCallingFinalize" />
     <rule ref="category/java/errorprone.xml/EmptyFinalizer" />
     <rule ref="category/java/errorprone.xml/FinalizeDoesNotCallSuperFinalize" />
@@ -92,11 +89,8 @@ under the License.
 
     <rule ref="category/java/bestpractices.xml/AvoidUsingHardCodedIP" />
     <rule ref="category/java/bestpractices.xml/CheckResultSet" />
-    <rule ref="category/java/bestpractices.xml/UnusedImports" />
     <rule ref="category/java/bestpractices.xml/LooseCoupling" />
     <rule ref="category/java/bestpractices.xml/AvoidStringBufferField" />
-    <rule ref="category/java/bestpractices.xml/LooseCoupling" />
-    <rule ref="category/java/bestpractices.xml/UnusedImports" />
 
     <rule ref="category/java/codestyle.xml/ExtendsObject" />
     <rule ref="category/java/codestyle.xml/ForLoopShouldBeWhileLoop" />
@@ -105,17 +99,10 @@ under the License.
     <rule ref="category/java/codestyle.xml/UselessParentheses" />
     <rule ref="category/java/codestyle.xml/UselessQualifiedThis" />
     <rule ref="category/java/codestyle.xml/UnnecessaryModifier" name="UnnecessaryFinalModifier" />
-    <rule ref="category/java/codestyle.xml/DontImportJavaLang" />
-    <rule ref="category/java/codestyle.xml/DuplicateImports" />
     <rule ref="category/java/codestyle.xml/TooManyStaticImports" />
     <rule ref="category/java/codestyle.xml/UnnecessaryFullyQualifiedName" />
-    <rule ref="category/java/codestyle.xml/ForLoopsMustUseBraces" />
-    <rule ref="category/java/codestyle.xml/IfElseStmtsMustUseBraces" />
-    <rule ref="category/java/codestyle.xml/IfStmtsMustUseBraces" />
-    <rule ref="category/java/codestyle.xml/WhileLoopsMustUseBraces" />
 
     <rule ref="category/java/performance.xml/BigIntegerInstantiation" />
-    <rule ref="category/java/performance.xml/BooleanInstantiation" />
     <rule ref="category/java/performance.xml/AppendCharacterWithChar" />
     <rule ref="category/java/performance.xml/ConsecutiveAppendsShouldReuse" />
     <rule ref="category/java/performance.xml/ConsecutiveLiteralAppends" />
@@ -139,12 +126,7 @@ under the License.
         <property name="minimum" value="57"/>
       </properties>
     </rule>
-    <rule ref="category/java/design.xml/ModifiedCyclomaticComplexity" />
-    <rule ref="category/java/design.xml/NcssConstructorCount" />
-    <rule ref="category/java/design.xml/NcssMethodCount" />
-    <rule ref="category/java/design.xml/NcssTypeCount" />
     <rule ref="category/java/design.xml/NPathComplexity" />
-    <rule ref="category/java/design.xml/StdCyclomaticComplexity" />
     <rule ref="category/java/design.xml/TooManyFields" >
       <properties>
         <property name="maxfields" value="101"/>

--- a/src/main/java/org/joinfaces/example/SecurityConfig.java
+++ b/src/main/java/org/joinfaces/example/SecurityConfig.java
@@ -40,6 +40,14 @@ import org.springframework.security.web.SecurityFilterChain;
 @EnableConfigurationProperties(ApplicationUsers.class)
 public class SecurityConfig {
 
+	/**
+	 * Setups a security filter chain that will be applied to all the requests.
+	 * Since JSF 2.2 there is already a CSRF protection, so the Spring CSRF protection must be disabled,
+	 * because it blocks AJAX requests.
+	 * @param http - autowired HttpSecurity object
+	 * @return SecurityFilterChain that contains all the security filters
+	 * @throws BeanCreationException if something in the configuration is wrong
+	 */
 	@SuppressFBWarnings("SPRING_CSRF_PROTECTION_DISABLED")
 	@Bean
 	public SecurityFilterChain configure(HttpSecurity http) {
@@ -62,11 +70,17 @@ public class SecurityConfig {
 				.logoutSuccessUrl("/login.jsf")
 				.deleteCookies("JSESSIONID");
 			return http.build();
-		} catch (Exception ex) {
+		}
+		catch (Exception ex) {
 			throw new BeanCreationException("Wrong spring security configuration", ex);
 		}
 	}
 
+	/**
+	 * UserDetailsService that configures an in-memory users store.
+	 * @param applicationUsers - autowired users from the application.yml file
+	 * @return InMemoryUserDetailsManager - a manager that keeps all the users' info in the memory
+	 */
 	@Bean
 	public InMemoryUserDetailsManager userDetailsService(ApplicationUsers applicationUsers) {
 		PasswordEncoder encoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();

--- a/src/main/java/org/joinfaces/example/SecurityConfig.java
+++ b/src/main/java/org/joinfaces/example/SecurityConfig.java
@@ -18,17 +18,17 @@ package org.joinfaces.example;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
 
 /**
  * Spring Security Configuration.
@@ -38,18 +38,14 @@ import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 @Configuration
 @EnableWebSecurity
 @EnableConfigurationProperties(ApplicationUsers.class)
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
+public class SecurityConfig {
 
-	@Autowired
-	private ApplicationUsers applicationUsers;
-
-	@SuppressFBWarnings({"SPRING_CSRF_PROTECTION_DISABLED", "THROWS_METHOD_THROWS_RUNTIMEEXCEPTION"})
-	@Override
-	protected void configure(HttpSecurity http) {
+	@SuppressFBWarnings("SPRING_CSRF_PROTECTION_DISABLED")
+	@Bean
+	public SecurityFilterChain configure(HttpSecurity http) {
 		try {
 			http.csrf().disable();
 			http
-				.userDetailsService(userDetailsService())
 				.authorizeRequests()
 				.antMatchers("/").permitAll()
 				.antMatchers("/**.jsf").permitAll()
@@ -65,17 +61,17 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 				.logout()
 				.logoutSuccessUrl("/login.jsf")
 				.deleteCookies("JSESSIONID");
-		}
-		catch (Exception ex) {
-			throw new RuntimeException(ex);
+			return http.build();
+		} catch (Exception ex) {
+			throw new BeanCreationException("Wrong spring security configuration", ex);
 		}
 	}
 
-	@Override
-	protected UserDetailsService userDetailsService() {
+	@Bean
+	public InMemoryUserDetailsManager userDetailsService(ApplicationUsers applicationUsers) {
 		PasswordEncoder encoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
 		InMemoryUserDetailsManager result = new InMemoryUserDetailsManager();
-		for (UserCredentials userCredentials : this.applicationUsers.getUsersCredentials()) {
+		for (UserCredentials userCredentials : applicationUsers.getUsersCredentials()) {
 			result.createUser(User.builder()
 				.username(userCredentials.getUsername())
 				.password(encoder.encode(userCredentials.getPassword()))

--- a/src/main/java/org/joinfaces/example/view/FreemarkerUtils.java
+++ b/src/main/java/org/joinfaces/example/view/FreemarkerUtils.java
@@ -29,7 +29,7 @@ import org.springframework.ui.freemarker.FreeMarkerTemplateUtils;
 import org.springframework.web.context.annotation.ApplicationScope;
 
 /**
- * Freemarker utitily class to merge map and templates.
+ * Freemarker utility class to merge map and templates.
  *
  * @author Marcelo Fernandes
  */

--- a/src/main/java/org/joinfaces/example/view/StarterMBean.java
+++ b/src/main/java/org/joinfaces/example/view/StarterMBean.java
@@ -172,10 +172,4 @@ public class StarterMBean implements Serializable {
 		map.put("starterMBean", this);
 		return this.freemarkerUtils.mergeTemplate(map, "pom.ftl");
 	}
-
-	/**
-	* Set pom map.
-	*/
-	public void setPom(String pom) {
-	}
 }

--- a/src/main/resources/META-INF/resources/login.xhtml
+++ b/src/main/resources/META-INF/resources/login.xhtml
@@ -20,8 +20,10 @@
                 <pe:layoutPane id="mainLayoutPane" position="center" >
                     <h:form prependId="false">
                         <div id="mainDiv" class="ui-fluid center">
-                            <p:outputLabel value="Connection failed: user and/or password are wrong." 
-                                           rendered="${!empty param['error']}"/>
+                            <p:panelGrid columns="1" layout="grid">
+                                <p:outputLabel value="Connection failed: user and/or password are wrong."
+                                               rendered="${!empty param['error']}"/>
+                            </p:panelGrid>
                             <p:focus />
                             <p:panelGrid columns="2" layout="grid">
                                 <h:outputText value="username" />

--- a/src/test/java/org/joinfaces/example/SecurityConfigIT.java
+++ b/src/test/java/org/joinfaces/example/SecurityConfigIT.java
@@ -16,11 +16,12 @@
 
 package org.joinfaces.example;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.BeanCreationException;
-
+@SuppressFBWarnings("THROWS_METHOD_THROWS_CLAUSE_THROWABLE")
 public class SecurityConfigIT {
 
 	@Test

--- a/src/test/java/org/joinfaces/example/SecurityConfigIT.java
+++ b/src/test/java/org/joinfaces/example/SecurityConfigIT.java
@@ -16,18 +16,17 @@
 
 package org.joinfaces.example;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.beans.factory.BeanCreationException;
 
-@SuppressFBWarnings("THROWS_METHOD_THROWS_CLAUSE_THROWABLE")
 public class SecurityConfigIT {
 
 	@Test
 	public void exceptionOnConfigureNull() {
-		Assertions.assertThrows(RuntimeException.class, () -> new SecurityConfig().configure((HttpSecurity) null));
+		SecurityConfig securityConfig = new SecurityConfig();
+		Assertions.assertThrows(BeanCreationException.class, () -> securityConfig.configure(null));
 	}
 
 }

--- a/src/test/java/org/joinfaces/example/view/AbstractPageIT.java
+++ b/src/test/java/org/joinfaces/example/view/AbstractPageIT.java
@@ -28,7 +28,7 @@ import org.openqa.selenium.firefox.FirefoxProfile;
 import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 import org.openqa.selenium.support.PageFactory;
 
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 
 /**
  * Abstract class to create utility methods to access WebClient and Page.

--- a/src/test/java/org/joinfaces/example/view/WelcomeConverterPageIT.java
+++ b/src/test/java/org/joinfaces/example/view/WelcomeConverterPageIT.java
@@ -35,7 +35,7 @@ public class WelcomeConverterPageIT extends AbstractPageIT {
 		page.navegateTo();
 
 		assertThat(page.getOutputText())
-			.isEqualTo("");
+			.isEmpty();
 	}
 
 	@Test


### PR DESCRIPTION
- Replaced deprecated **WebSecurityConfigurerAdapter** with **SecurityFilterChain**
and adapted the tests (userDetailsService will be automatically picked).
For more see: [Spring Security without the webSecurityConfigurerAdapter](https://spring.io/blog/2022/02/21/spring-security-without-the-websecurityconfigureradapter)
- Fixed the black text on the dark background UI bug.
- Fixed typos and removed a redundant setter.